### PR TITLE
v0.2.5 - Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
 # ats-docker
 Apache TrafficServer Dockerfiles
 
+## Goals
+TODO
+
+## TLDR
+
+```bash
+# Build images first
+bash build.sh # builds base, devel (local repo), and master (master repo)
+
+# Run containers
+bash run.sh devel # runs devel (local dev repo ./trafficserver)
+# OR
+bash run.sh tag master # runs master
+# OR with mounted config files which are in ./configs
+bash run.sh devel -m
+# OR
+bash run.sh tag master -m
+
+# See Logs of running container
+docker logs <container id from after running the above>
+
+# Thats it!
+```
+
 ## Building
 
 ### All
@@ -73,3 +97,6 @@ Below are common docker issues.
     # stop and/or kill the pid, then start the daemon.
     sudo /etc/init.d/docker restart
     ```
+
+  * *NOTE*: please note that traffic_cop will switch users and the ENV var will not be
+    carried over.

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,17 @@
 - [x] On CMD run traffic_cop
 - [x] On CMD also tail logs
 - [x] On docker run expose all ports and detach
+
+v0.2.5 - Run
+- [x] FIX shared lib, due to user switching of TS daemons
+  - [x] add to devel configs
+  - [x] add `/usr/local/etc/trafficserver/snapshots` dir to base template
+  - [x] add config param to ats command
+  - [x] Readme note that to override, simply supply own configs
+  - [x] move fingerprinting and user switching toggle to generated files prior to `make install`
+        rather than using the template `.in` file.
+- [x] Embed dockerfile
+
 - [ ] Run specifying a single remap config file
 - [ ] Run Cache mount
 - [ ] Better logging?

--- a/configs/records.config
+++ b/configs/records.config
@@ -197,3 +197,8 @@ CONFIG proxy.config.cluster.cluster_port INT 8086
 CONFIG proxy.config.cluster.rsport INT 8088
 CONFIG proxy.config.cluster.mcport INT 8089
 CONFIG proxy.config.cluster.mc_group_addr STRING 224.0.1.37
+
+# Docker CMD runs traffic_cop, user switching to other daemons required disabling
+# For a more secure system consider supplying your own configs and further
+# modify the container with finite permissions.
+CONFIG proxy.config.admin.user_id STRING #-1

--- a/templates/base.tpl
+++ b/templates/base.tpl
@@ -23,5 +23,11 @@ git
 RUN sudo apt-get install -y gdb valgrind git ack-grep curl \
 tmux screen ccache python-sphinx doxygen python-lxml
 
+# Snapshot dir
+RUN mkdir -p /usr/local/etc/trafficserver/snapshots
+
 # Add helper
 ADD ./ats.sh /ats.sh
+
+# Add Dockerfile for reference
+ADD ./_Dockerfile /Dockerfile

--- a/templates/branch.tpl
+++ b/templates/branch.tpl
@@ -1,6 +1,9 @@
 FROM ats:base
 MAINTAINER apache-traffic-server
 
+# Add Dockerfile for reference
+ADD ./_Dockerfile /Dockerfile
+
 # proxy port     - proxy.config.http.server_ports
 EXPOSE 8080
 

--- a/templates/devel.tpl
+++ b/templates/devel.tpl
@@ -1,6 +1,9 @@
 FROM ats:base
 MAINTAINER apache-traffic-server
 
+# Add Dockerfile for reference
+ADD ./_Dockerfile /Dockerfile
+
 ADD ./trafficserver $BUILD_LOC
 
 # proxy port     - proxy.config.http.server_ports


### PR DESCRIPTION
- [x] FIX shared lib, due to user switching of TS daemons
  - [x] add to devel configs
  - [x] add `/usr/local/etc/trafficserver/snapshots` dir to base template
  - [x] add config param to ats command
  - [x] Readme note that to override, simply supply own configs
  - [x] move fingerprinting and user switching toggle to generated files prior to `make install`
      rather than using the template `.in` file.
- [x] Embed dockerfile
